### PR TITLE
Started to fix unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux, macos
 language: python
 python:
-  - 3.4
+#  - 3.4
   - 3.7
 
 before_install:

--- a/rootwater/tests/core.py
+++ b/rootwater/tests/core.py
@@ -1,39 +1,41 @@
 import unittest
 
+import os
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_almost_equal
 
-import rootwater 
+from rootwater import rw, sf
 
-# read references
-SMtest = pd.read_csv('tests/SM_test.csv',index_col=0)
-SMtest.index = pd.to_datetime(SMtest.index)
+# get the basebath for test reference files
+BASEPATH = os.path.abspath(os.path.dirname(__file__))
 
-RWUtest = pd.read_csv('tests/RWU_test.csv',index_col=0)
-RWUtest.index = pd.to_datetime(RWUtest.index)
-
-SFtest = pd.read_csv('tests/SF_test.csv',index_col=0)
-SFtest.index = pd.to_datetime(SFtest.index)
-
-SVtest = pd.read_csv('tests/SV_test.csv',index_col=0)
-SVtest.index = pd.to_datetime(SVtest.index)
-
+def _read_helper(fname):
+    df = pd.read_csv(os.path.join(BASEPATH, fname),index_col=0)
+    df.index = pd.to_datetime(df.index)
+    return df
 
 
 class TestIt(unittest.TestCase):
+    def setUp(self):
+        # read references
+        self.SMtest = _read_helper('SM_test.csv')
+        self.RWUtest = _read_helper('RWU_test.csv')
+        self.SFtest = _read_helper('SF_test.csv')
+        self.SVtest = _read_helper('SV_test.csv')
+
     def test_RWU(self):
         assert_almost_equal(
-            pd.concat(rw.dfRWUc(SMtest)).dropna().values,
-            RWUtest.values,
+            pd.concat(rw.dfRWUc(self.SMtest)).dropna().values,
+            self.RWUtest.values,
             decimal=2
             )
         
 
     def test_SF(self):
         assert_almost_equal(
-            sf.sap_calc(SVtest,32.,'beech').values,
-            SFtest.values,
+            sf.sap_calc(self.SVtest,32.,'beech').values,
+            self.SFtest.values,
             decimal=2
         )
 


### PR DESCRIPTION
Hey Conrad,

I started to fix the unit tests. There were/are several problems. 
First, I would exclude the Python3.4 test for now, unit the 3.7 are working correctly (See my commit [#aa12f88](https://github.com/cojacoo/rootwater/commit/aa12f888620bee7e367fe6d180a5b863561b6f39)). At first glance, the problem is the scipy version (1.4), which does not support 3.4. BTW Py3.4 is deprecated and I think there is no need to support it.
Second, I fixed the paths in the unit tests core.py. However, there is still a error occuring:

```
Traceback (most recent call last):
  File "d:/Dropbox/python/rootwater/rootwater/tests/core.py", line 37, in test_SF
    sf.sap_calc(self.SVtest,32.,'beech').values,
  File "d:\dropbox\python\rootwater\rootwater\sapflow.py", line 152, in sap_calc
    Sap.loc[i,colx[0]] = sap_volume(r,SV.loc[i,colx[1]],SV.loc[i,colx[0]],False,tree)
  File "d:\dropbox\python\rootwater\rootwater\sapflow.py", line 113, in sap_volume
    v3 = dummy[(np.arange(50)/50.*gebauer(r,tree) > 2.4) & (np.arange(50)/50.*gebauer(r,tree) <= gebauer_act(r,perc,tree))]
  File "d:\dropbox\python\rootwater\rootwater\sapflow.py", line 85, in gebauer_act
    return np.where(np.cumsum(gebauer_rel(r,tree))/sum(gebauer_rel(r,tree))>perc)[0][0]/50.*gebauer(r,tree)
TypeError: '>' not supported between instances of 'numpy.ndarray' and 'str'
``` 

I think the `tree` gets misused somewhere on that line, but not sure what's going on. Either `gebauer_rel()` is returning a string or `perc` is a string at runtime.  
Do you have an idea how this error is caused? May be easier to fix for you than for me...